### PR TITLE
Path don't work on Linux beause of case sensitiveness (FIX)

### DIFF
--- a/files.qip
+++ b/files.qip
@@ -19,7 +19,7 @@ set_global_assignment -name VHDL_FILE rtl/Midway_Tone_Gen.vhd
 set_global_assignment -name VHDL_FILE rtl/OVO.vhd
 set_global_assignment -name VHDL_FILE rtl/bb_clouds.vhd
 set_global_assignment -name VHDL_FILE rtl/bb_audio.vhd
-set_global_assignment -name VHDL_FILE rtl/polaris_cloud.vhd
+set_global_assignment -name VHDL_FILE rtl/Polaris_cloud.vhd
 set_global_assignment -name VHDL_FILE rtl/zap_audio.vhd
 set_global_assignment -name VHDL_FILE rtl/maze_audio.vhd
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/virtualgun.sv


### PR DESCRIPTION
There is a file rtl/Polaris_cloud.vhd that is referenced by the string 'rtl/polaris_cloud.vhd'.

This works on Windows, because its file system is case insensitive.

But fails on Linux.

This PR fixes that.